### PR TITLE
Fix sync_renew_dates timeouts

### DIFF
--- a/views/default/audit_domains.pdt
+++ b/views/default/audit_domains.pdt
@@ -18,7 +18,7 @@ $this->Widget->create($this->_("Namesilo.add_row.audit_domains.box_title", true)
         foreach($vars->domains as $domain){
             ?>
                 <tr>
-                    <td><?php echo $this->Html->ifSet($service['domain']); ?></td>
+                    <td><?php echo $this->Html->ifSet($domain); ?></td>
                     <td>No corresponding billing record in Blesta.</td>
                 </tr>
             <?php

--- a/views/default/sync_renew_dates.pdt
+++ b/views/default/sync_renew_dates.pdt
@@ -1,3 +1,45 @@
+<script>
+    var service_ids = JSON.parse('<?php print(json_encode($vars['service_ids'])); ?>');
+    var services_done = 0;
+
+    $(function() {
+        $('span#services_total').text(service_ids.length);
+        run_check();
+    });
+
+    function run_check () {
+        var new_row;
+        var button;
+        var service_id = service_ids.pop();
+        if(service_id !== undefined) {
+            $.getJSON(
+                '<?php print($url) ?>',
+                {
+                    'service_id': service_id,
+                    'action': 'get_renew_info'
+                }
+            ).done(function (output) {
+                if(output.hasOwnProperty("error") && !output.error){
+                    new_row = $('<tr></tr>');
+                    button = $('<input type="checkbox" name="sync_services[]" checked="checked">').val(output.service_id);
+                    new_row.append($('<td></td>').append(button))
+                    new_row.append($('<td></td>').text(output.domain));
+                    new_row.append($('<td></td>').text(output.date_before));
+                    new_row.append($('<td></td>').text(output.date_after));
+                    $('tbody#domain_changes').append(new_row);
+                } else if(output.hasOwnProperty("error") && output.error){
+                    new_row = $('<tr></tr>');
+                    new_row.append($('<td></td>').text(output.domain));
+                    new_row.append($('<td></td>').text(output.error.detail));
+                    $('tbody#domain_errors').append(new_row);
+                }
+                services_done++;
+                $('span#services_done').text(services_done);
+                setTimeout(run_check, 100);
+            });
+        }
+    };
+</script>
 <?php
 
 if(isset($_REQUEST['msg'])) {
@@ -16,69 +58,36 @@ $this->Widget->clear();
 $this->Widget->create($this->_("Namesilo.manage.sync_renew_dates.box_title", true));
 ?>
 <div class="inner">
+    <p>Services checked:<span id="services_done">0</span>/<span id="services_total">0</span></p>
     <p><?php echo $this->_("Namesilo.manage.sync_renew_dates.description", true); ?></p>
-    <?php if(count($vars['changes']) > 0){ ?>
     <div class="title_row first">
         <h3><?php $this->_("Namesilo.manage.sync_renew_dates.out_of_sync");?></h3>
     </div>
     <?php $this->Form->create(); ?>
     <table class="table">
-        <tbody>
+        <tbody id="domain_changes">
             <tr class="heading_row">
                 <td></td>
                 <td><?php echo $this->_("Namesilo.domain.domain", true); ?></td>
                 <td>Old Renew Date</td>
                 <td>New Renew Date</td>
             </tr>
-            <?php
-            foreach($vars['changes'] as $change){
-                if(isset($change['error']) && !$change['error']) {
-                    ?>
-                    <tr>
-                        <td>
-                            <?php
-                            $this->Form->fieldCheckbox("sync_services[]", $this->Html->ifSet($change['service_id']), "true");
-                            ?>
-                        </td>
-                        <td><?php echo $this->Html->ifSet($change['domain']); ?></td>
-                        <td><?php echo $this->Html->ifSet($change['date_before']); ?></td>
-                        <td><?php echo $this->Html->ifSet($change['date_after']); ?></td>
-                    </tr>
-                    <?php
-                }
-            }
-            ?>
         </tbody>
     </table>
     <div class="button_row"><a class="btn_right submit" href="#"><?php $this->_("Namesilo.manage.sync_renew_dates.sync_btn");?></a></div>
     <?php $this->Form->end(); ?>
-    <?php } ?>
 
-    <?php if(count($vars['changes']) > 0){ ?>
     <div class="title_row first" style="margin-top:15px !important">
         <h3><?php $this->_("Namesilo.manage.sync_renew_dates.errors");?></h3>
     </div>
     <table class="table">
-        <tbody>
+        <tbody id="domain_errors">
             <tr class="heading_row">
                 <td><?php echo $this->_("Namesilo.domain.domain", true); ?></td>
                 <td>Result</td>
             </tr>
-            <?php
-            foreach($vars['changes'] as $change){
-                if(isset($change['error']) && $change['error']) {
-                    ?>
-                    <tr>
-                        <td><?php echo $this->Html->ifSet($change['domain']); ?></td>
-                        <td><?php echo $this->Html->ifSet($change['error']['detail']); ?></td>
-                    </tr>
-                    <?php
-                }
-            }
-            ?>
         </tbody>
     </table>
-    <?php } ?>
 
 </div>
 <?php


### PR DESCRIPTION
Doing it all via PHP caused it to hit webserver timeouts. This does one
request at a time to Blesta which will then make a request to NameSilo.

It has to be one at a time to prevent NameSilo from returning 'null'
from making too many requests.
