### PR TITLE
Sync Renew Dates: Highlight rows with large diffs

### DIFF
--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -28,7 +28,7 @@ $lang['Namesilo.manage.audit_domains.results'] = "Audit Results";
 
 // Sync renew dates
 $lang['Namesilo.manage.sync_renew_dates.box_title'] = "Sync Domain Renewal Dates";
-$lang['Namesilo.manage.sync_renew_dates.description'] = "This tool synchronizes a service's renewal date with the domain's actual expiration date, taking into account the suspension threshold (as to ensure auto-renewal doesn't renew the domain if the customer hasn't paid).";
+$lang['Namesilo.manage.sync_renew_dates.description'] = "This tool synchronizes a service's renewal date with the domain's actual expiration date, taking into account the suspension threshold (as to ensure auto-renewal doesn't renew the domain if the customer hasn't paid). Highlighted rows have a difference greater than 9 months (270 days) and should be checked before syncing.";
 $lang['Namesilo.manage.sync_renew_dates.results'] = "Synchronization Results";
 $lang['Namesilo.manage.sync_renew_dates.out_of_sync'] = "Out Of Sync Renew Dates";
 $lang['Namesilo.manage.sync_renew_dates.errors'] = "Errors";

--- a/namesilo.php
+++ b/namesilo.php
@@ -2302,15 +2302,27 @@ class Namesilo extends Module {
         $target_date_obj = $expires->modify("- " . (3 + $suspend_days) . " days");
         $target_date = $target_date_obj->format('Y-m-d H:i:s');
 
-        if($date_renews->diff($target_date_obj)->format('%a') > 0){
+        if($date_renews->diff($target_date_obj)->format('%a') >= 90){
             $vars = array(
                 'service_id' => $service_id,
                 'domain' => $service->name,
                 'date_before' => $date_renews->format('Y-m-d H:i:s'),
                 'date_after' => $target_date,
-                'error' => false
+                'error' => false,
+                'checked' => false,
+                'highlight' => true
             );
-        }
+        } elseif ($date_renews->diff($target_date_obj)->format('%a') > 0) {
+            $vars = array(
+                'service_id' => $service_id,
+                'domain' => $service->name,
+                'date_before' => $date_renews->format('Y-m-d H:i:s'),
+                'date_after' => $target_date,
+                'error' => false,
+                'checked' => true,
+                'highlight' => false
+            );
+		}
 
         return $vars;
     }

--- a/views/default/sync_renew_dates.pdt
+++ b/views/default/sync_renew_dates.pdt
@@ -21,8 +21,12 @@
             ).done(function (output) {
                 if(output.hasOwnProperty("error") && !output.error){
                     new_row = $('<tr></tr>');
-                    button = $('<input type="checkbox" name="sync_services[]" checked="checked">').val(output.service_id);
-                    new_row.append($('<td></td>').append(button))
+                    checkbox = $('<input type="checkbox" name="sync_services[]">').val(output.service_id);
+                    checkbox.prop("checked", output.checked);
+                    if (output.highlight) {
+                        new_row.css("background-color", "yellow");
+                    }
+                    new_row.append($('<td></td>').append(checkbox))
                     new_row.append($('<td></td>').text(output.domain));
                     new_row.append($('<td></td>').text(output.date_before));
                     new_row.append($('<td></td>').text(output.date_after));


### PR DESCRIPTION
The return from getRenewInfo() includes two new keys,
highlight and checked, which is used by sync_renew_dates.pdt
to determine if the row should be highlighted or checked.